### PR TITLE
Removed URL percent encoding (#1) & other improvements

### DIFF
--- a/build.py
+++ b/build.py
@@ -55,8 +55,6 @@ GODOT_CPP_API_PATH=''
 ARCHI = machine()
 NPROC = str(cpu_count())
 OSTYPE = system()
-if os.name == "nt" and get_platform().startswith("mingw"):
-    OSTYPE = "MinGW"
 
 ###############################################################################
 ### Green color message

--- a/build.py
+++ b/build.py
@@ -55,8 +55,8 @@ GODOT_CPP_API_PATH=''
 ARCHI = machine()
 NPROC = str(cpu_count())
 OSTYPE = system()
-# if os.name == "nt" and get_platform().startswith("mingw"):
-    # OSTYPE = "MinGW"
+if os.name == "nt" and get_platform().startswith("mingw"):
+    OSTYPE = "MinGW"
 
 ###############################################################################
 ### Green color message

--- a/build.py
+++ b/build.py
@@ -37,7 +37,7 @@ from multiprocessing import cpu_count
 
 ###############################################################################
 ### Global user settings
-CEF_VERSION = "102.0.9+g1c5e658+chromium-102.0.5005.63"
+CEF_VERSION = "103.0.10+ga5c79bb+chromium-103.0.5060.114"
 CEF_TARGET = "Release"     # "Debug"
 MODULE_TARGET = "release"  # "debug"
 
@@ -55,8 +55,8 @@ GODOT_CPP_API_PATH=''
 ARCHI = machine()
 NPROC = str(cpu_count())
 OSTYPE = system()
-if os.name == "nt" and get_platform().startswith("mingw"):
-    OSTYPE = "MinGW"
+# if os.name == "nt" and get_platform().startswith("mingw"):
+    # OSTYPE = "MinGW"
 
 ###############################################################################
 ### Green color message
@@ -195,7 +195,7 @@ def download_cef():
         info(CEF_VERSION + " already downloaded")
     else:
         # Replace the '+' chars by URL percent encoding '%2B'
-        CEF_URL_VERSION = CEF_VERSION.replace("+", "%2B")
+        CEF_URL_VERSION = CEF_VERSION
         CEF_TARBALL = "cef_binary_" + CEF_URL_VERSION + "_" + CEF_ARCHI + ".tar.bz2"
         info("Downloading Chromium Embedded Framework into " + CEF_PATH + " ...")
 

--- a/build.py
+++ b/build.py
@@ -321,7 +321,7 @@ def compile_gdnative_cef(path):
         gdnative_scons_cmd("x11")
     elif OSTYPE == "Darwin":
         gdnative_scons_cmd("osx")
-    elif OSTYPE == "Windows" or OSTYPE == "MinGW":
+    elif OSTYPE == "Windows":
         gdnative_scons_cmd("windows")
     else:
         fatal("Unknown archi " + OSTYPE + ": I dunno how to compile CEF module primary process")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-wget
+python3-wget
 scons
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+wget
+scons
+packaging


### PR DESCRIPTION
Changes in `build.py`:

- CEF-Version updated
- OS name check causes build.py to exit on Windows
- ~~Removed URL percent encoding, as it causes my error described in #1~~

Added:

- requirements.txt - this file is used in conjunction with pip to install the (missing) requirements faster with `pip install -r requirements.txt`