### PR TITLE
Javascript injection demo

### DIFF
--- a/addons/gdcef/demos/2D/CEF.gd
+++ b/addons/gdcef/demos/2D/CEF.gd
@@ -73,6 +73,24 @@ func _on_Home_pressed():
 	pass
 
 # ==============================================================================
+# Color button pressed: present a pop-up to change the background color
+# ==============================================================================
+func _on_BGColor_pressed():
+	if $ColorPopup.visible:
+		$ColorPopup.popup_hide()
+	else:
+		$ColorPopup.popup_centered(Vector2(0,0))
+
+# ==============================================================================
+# color picker changed: inject javascript to change background color
+# ==============================================================================
+func _on_ColorPicker_color_changed(color):
+	if current_browser != null:
+		var js_string = 'document.body.style.background = "#%s"' % color.to_html(false)
+		print(js_string)
+		current_browser.execute_javascript(js_string)
+
+# ==============================================================================
 # Go to previously visited page
 # ==============================================================================
 func _on_Prev_pressed():

--- a/addons/gdcef/demos/2D/CEF.gd
+++ b/addons/gdcef/demos/2D/CEF.gd
@@ -87,7 +87,6 @@ func _on_BGColor_pressed():
 func _on_ColorPicker_color_changed(color):
 	if current_browser != null:
 		var js_string = 'document.body.style.background = "#%s"' % color.to_html(false)
-		print(js_string)
 		current_browser.execute_javascript(js_string)
 
 # ==============================================================================

--- a/addons/gdcef/demos/2D/CEF.tscn
+++ b/addons/gdcef/demos/2D/CEF.tscn
@@ -46,45 +46,51 @@ text = "Tabs:"
 
 [node name="BrowserList" type="OptionButton" parent="Panel/VBox/HBox"]
 margin_left = 61.0
-margin_right = 333.0
+margin_right = 317.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="URL" type="Label" parent="Panel/VBox/HBox"]
-margin_left = 337.0
+margin_left = 321.0
 margin_top = 5.0
-margin_right = 366.0
+margin_right = 350.0
 margin_bottom = 19.0
 rect_pivot_offset = Vector2( 34, 14 )
 mouse_filter = 0
 text = "URL:"
 
 [node name="TextEdit" type="LineEdit" parent="Panel/VBox/HBox"]
-margin_left = 370.0
-margin_right = 643.0
+margin_left = 354.0
+margin_right = 610.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="Prev" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 647.0
-margin_right = 667.0
+margin_left = 614.0
+margin_right = 634.0
 margin_bottom = 24.0
 text = "<"
 
 [node name="Home" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 671.0
-margin_right = 722.0
+margin_left = 638.0
+margin_right = 689.0
 margin_bottom = 24.0
 text = "Home"
 
+[node name="BGColor" type="Button" parent="Panel/VBox/HBox"]
+margin_left = 693.0
+margin_right = 738.0
+margin_bottom = 24.0
+text = "Color"
+
 [node name="Next" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 726.0
-margin_right = 746.0
+margin_left = 742.0
+margin_right = 762.0
 margin_bottom = 24.0
 text = ">"
 
 [node name="Info" type="Label" parent="Panel/VBox/HBox"]
-margin_left = 750.0
+margin_left = 766.0
 margin_top = 5.0
 margin_right = 1023.0
 margin_bottom = 19.0
@@ -102,11 +108,27 @@ size_flags_vertical = 3
 expand = true
 stretch_mode = 3
 
+[node name="ColorPopup" type="WindowDialog" parent="."]
+margin_left = 348.0
+margin_top = 81.0
+margin_right = 664.0
+margin_bottom = 501.0
+window_title = "Javascript Injection Example: Color Picker"
+
+[node name="ColorPicker" type="ColorPicker" parent="ColorPopup"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+edit_alpha = false
+presets_enabled = false
+presets_visible = false
+
 [connection signal="pressed" from="Panel/VBox/HBox/Add" to="." method="_on_Add_pressed"]
 [connection signal="item_selected" from="Panel/VBox/HBox/BrowserList" to="." method="_on_BrowserList_item_selected"]
 [connection signal="text_changed" from="Panel/VBox/HBox/TextEdit" to="." method="_on_TextEdit_text_changed"]
 [connection signal="pressed" from="Panel/VBox/HBox/Prev" to="." method="_on_Prev_pressed"]
 [connection signal="pressed" from="Panel/VBox/HBox/Home" to="." method="_on_Home_pressed"]
-[connection signal="pressed" from="Panel/VBox/HBox/Next" to="." method="_on_Prev_pressed"]
+[connection signal="pressed" from="Panel/VBox/HBox/BGColor" to="." method="_on_BGColor_pressed"]
 [connection signal="pressed" from="Panel/VBox/HBox/Next" to="." method="_on_Next_pressed"]
+[connection signal="pressed" from="Panel/VBox/HBox/Next" to="." method="_on_Prev_pressed"]
 [connection signal="gui_input" from="Panel/VBox/TextureRect" to="." method="_on_TextureRect_gui_input"]
+[connection signal="color_changed" from="ColorPopup/ColorPicker" to="." method="_on_ColorPicker_color_changed"]

--- a/addons/gdcef/gdcef/src/gdbrowser.cpp
+++ b/addons/gdcef/gdcef/src/gdbrowser.cpp
@@ -248,7 +248,7 @@ void GDBrowserView::stopLoading()
 void GDBrowserView::executeJavaScript(godot::String javascript)
 {
 
-    if (!m_browser && m_browser->GetMainFrame())
+    if (m_browser && m_browser->GetMainFrame())
     {
         CefString codeStr;
         codeStr.FromString(javascript.utf8().get_data());


### PR DESCRIPTION
Adds a color picker button to the 2D demo, which injects JavaScript to change the background of the page. Not super useful, but it should be a good demonstration on how to use the new javascript execution functionality

Also fixes a bug in the null check of `executeJavaScript` that was causing it to fail

Fixes: https://github.com/Lecrapouille/gdcef/issues/21