### PR TITLE
Initial port to Godot 4.2

### DIFF
--- a/addons/gdcef/build.py
+++ b/addons/gdcef/build.py
@@ -42,10 +42,9 @@ from packaging import version
 CEF_VERSION = "110.0.27+g1296c82+chromium-110.0.5481.100"
 CEF_TARGET = "Release"             # or "Debug"
 MODULE_TARGET = "release"          # or "debug"
-GODOT_CPP_TARGET = "release"       # or "debug"
-GODOT_VERSION = "4.0"              # or "master" or "3.5" or "3.4"
+GODOT_CPP_TARGET = "template_release"       # or "template_debug"
+GODOT_VERSION = "4.2"              # or "master" or "3.5" or "3.4"
 CMAKE_MIN_VERSION = "3.19"         # Minimun CMake version needed for compiling CEF
-GODOT_EXECUTABLE = "godot"         # Adapt the path to your Godot-4 path (not used for Godot-3)
 
 PWD = os.getcwd()
 GDCEF_PATH = os.path.join(PWD, "gdcef")
@@ -207,12 +206,6 @@ def check_paths():
             fatal('Please remove manually ' + CEF_ARTIFACTS_BUILD_PATH + ' and recall this script')
 
 ###############################################################################
-### Check if the Godot used is Godot-4
-# FIXME do proper check
-def is_godot4():
-    return (GODOT_VERSION == "4.0") or (GODOT_VERSION == "master")
-
-###############################################################################
 ### Download prebuild Chromium Embedded Framework if folder is not present
 def download_cef():
     if OSTYPE == "Linux":
@@ -274,10 +267,11 @@ def compile_cef():
         info("Compiling Chromium Embedded Framework in " + CEF_TARGET +
              " mode (inside " + THIRDPARTY_CEF_PATH + ") ...")
 
+        # TODO Godot 4: don't know why these patches were necessary in the past, but they seem to break things now
         # Apply patches for Windows
-        if OSTYPE == "Windows":
-            shutil.copyfile(os.path.join(PATCHES_PATH, "CEF", "win", "libcef_dll_wrapper_cmake"),
-                            "CMakeLists.txt")
+        #if OSTYPE == "Windows":
+        #    shutil.copyfile(os.path.join(PATCHES_PATH, "CEF", "win", "libcef_dll_wrapper_cmake"),
+        #                    "CMakeLists.txt")
 
         # Windows: force compiling CEF as static library.
         if OSTYPE == "Windows":
@@ -351,30 +345,28 @@ def download_godot_cpp():
         mkdir(GODOT_CPP_API_PATH)
         run(["git", "clone", "--recursive", "-b", GODOT_VERSION,
              "https://github.com/godotengine/godot-cpp", GODOT_CPP_API_PATH])
-        if is_godot4():
-            run([GODOT_EXECUTABLE, "--dump-extension-api", "extension_api.json"])
 
 ###############################################################################
 ### Compile Godot cpp wrapper needed for our gdnative code: CEF ...
 def compile_godot_cpp():
-    #lib = os.path.join(GODOT_CPP_API_PATH, "bin", "libgodot-cpp.linux.template_debug.x86_64.a") # "libgodot-cpp*" + GODOT_CPP_TARGET + "*")
-    if 1 == 1: #not os.path.exists(lib):
+    lib = os.path.join(GODOT_CPP_API_PATH, "bin", "libgodot-cpp*" + GODOT_CPP_TARGET + "*")
+    if not os.path.exists(lib):
         info("Compiling Godot C++ API (inside " + GODOT_CPP_API_PATH + ") ...")
         os.chdir(GODOT_CPP_API_PATH)
         if OSTYPE == "Linux":
-            run(["scons", "platform=linux", #"target=" + GODOT_CPP_TARGET,
-                 "custom_api_file=" + os.path.join(PWD, "extension_api.json"), "--jobs=" + NPROC], check=True)
+            run(["scons", "platform=linux", "target=" + GODOT_CPP_TARGET, "use_static_cpp=no",
+                 "--jobs=" + NPROC], check=True)
         elif OSTYPE == "Darwin":
             run(["scons", "platform=osx", "macos_arch=" + ARCHI,
-                 "custom_api_file=extension_api.json", "target=" + GODOT_CPP_TARGET,
+                 "target=" + GODOT_CPP_TARGET, "use_static_cpp=no",
                  "--jobs=" + NPROC], check=True)
         elif OSTYPE == "MinGW":
             run(["scons", "platform=windows", "use_mingw=True",
-                 "custom_api_file=extension_api.json", "target=" + GODOT_CPP_TARGET,
+                 "target=" + GODOT_CPP_TARGET, "use_static_cpp=no",
                  "--jobs=" + NPROC], check=True)
         elif OSTYPE == "Windows":
-            run(["scons", "platform=windows", "target=" + GODOT_CPP_TARGET,
-                 "custom_api_file=extension_api.json", "--jobs=" + NPROC], check=True)
+            run(["scons", "platform=windows", "target=" + GODOT_CPP_TARGET, "use_static_cpp=no",
+                 "--jobs=" + NPROC], check=True)
         else:
             fatal("Unknown architecture " + OSTYPE + ": I dunno how to compile Godot-cpp")
 
@@ -390,7 +382,6 @@ def gdnative_scons_cmd(plateform):
              "target=" + MODULE_TARGET, "--jobs=" + NPROC,
              "arch=" + ARCHI, "platform=" + plateform], check=True)
     else:
-        info("QQQQQQ")
         run(["scons", "api_path=" + GODOT_CPP_API_PATH,
              "cef_artifacts_folder=\\\"" + CEF_ARTIFACTS_FOLDER + "\\\"",
              "build_path=" + CEF_ARTIFACTS_BUILD_PATH,

--- a/addons/gdcef/demos/2D/CEF.tscn
+++ b/addons/gdcef/demos/2D/CEF.tscn
@@ -1,135 +1,99 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource path="res://CEF.gd" type="Script" id=1]
-[ext_resource path="res://libs/gdcef.gdns" type="Script" id=2]
+[ext_resource type="Script" path="res://CEF.gd" id="1"]
 
 [node name="GUI" type="Control"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 1
-script = ExtResource( 1 )
+script = ExtResource("1")
 
-[node name="CEF" type="Node" parent="."]
-script = ExtResource( 2 )
+[node name="CEF" type="GDCef" parent="."]
 
 [node name="Panel" type="Panel" parent="."]
+layout_mode = 0
 anchor_right = 2.504
 anchor_bottom = 1.856
-margin_left = -1.0
-margin_right = -1541.1
-margin_bottom = -513.6
+offset_right = -1604.61
+offset_bottom = -482.688
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="VBox" type="VBoxContainer" parent="Panel"]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_vertical = 3
 
 [node name="HBox" type="HBoxContainer" parent="Panel/VBox"]
-margin_right = 1023.0
-margin_bottom = 24.0
+layout_mode = 2
 
 [node name="Mute" type="Button" parent="Panel/VBox/HBox"]
-margin_right = 24.0
-margin_bottom = 24.0
+layout_mode = 2
 text = "M"
 
 [node name="Add" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 28.0
-margin_right = 48.0
-margin_bottom = 24.0
+layout_mode = 2
 text = "+"
 
 [node name="Tabs" type="Label" parent="Panel/VBox/HBox"]
-margin_left = 52.0
-margin_top = 5.0
-margin_right = 85.0
-margin_bottom = 19.0
-rect_pivot_offset = Vector2( 34, 14 )
+layout_mode = 2
 mouse_filter = 0
 text = "Tabs:"
 
 [node name="BrowserList" type="OptionButton" parent="Panel/VBox/HBox"]
-margin_left = 89.0
-margin_right = 336.0
-margin_bottom = 24.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="URL" type="Label" parent="Panel/VBox/HBox"]
-margin_left = 340.0
-margin_top = 5.0
-margin_right = 369.0
-margin_bottom = 19.0
-rect_pivot_offset = Vector2( 34, 14 )
+layout_mode = 2
 mouse_filter = 0
 text = "URL:"
 
 [node name="TextEdit" type="LineEdit" parent="Panel/VBox/HBox"]
-margin_left = 373.0
-margin_right = 620.0
-margin_bottom = 24.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Prev" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 624.0
-margin_right = 644.0
-margin_bottom = 24.0
+layout_mode = 2
 text = "<"
 
 [node name="Home" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 648.0
-margin_right = 699.0
-margin_bottom = 24.0
+layout_mode = 2
 text = "Home"
 
 [node name="BGColor" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 703.0
-margin_right = 748.0
-margin_bottom = 24.0
+layout_mode = 2
 text = "Color"
 
 [node name="Next" type="Button" parent="Panel/VBox/HBox"]
-margin_left = 752.0
-margin_right = 772.0
-margin_bottom = 24.0
+layout_mode = 2
 text = ">"
 
 [node name="Info" type="Label" parent="Panel/VBox/HBox"]
-margin_left = 776.0
-margin_top = 5.0
-margin_right = 1023.0
-margin_bottom = 19.0
-mouse_filter = 0
+layout_mode = 2
 size_flags_horizontal = 3
+mouse_filter = 0
 text = "info"
 
 [node name="TextureRect" type="TextureRect" parent="Panel/VBox"]
-margin_top = 28.0
-margin_right = 1023.0
-margin_bottom = 600.0
-rect_min_size = Vector2( 1, 1 )
-mouse_filter = 0
+layout_mode = 2
 size_flags_vertical = 3
-expand = true
+mouse_filter = 0
+expand_mode = 1
 stretch_mode = 3
 
-[node name="ColorPopup" type="WindowDialog" parent="."]
-margin_left = 348.0
-margin_top = 81.0
-margin_right = 664.0
-margin_bottom = 501.0
-window_title = "Javascript Injection Example: Color Picker"
+[node name="ColorPopup" type="Popup" parent="."]
 
 [node name="ColorPicker" type="ColorPicker" parent="ColorPopup"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 12.0
-margin_top = 12.0
-margin_right = 12.0
-margin_bottom = 12.0
 edit_alpha = false
-presets_enabled = false
 presets_visible = false
 
 [connection signal="pressed" from="Panel/VBox/HBox/Mute" to="." method="_on_Mute_pressed"]
@@ -139,7 +103,7 @@ presets_visible = false
 [connection signal="pressed" from="Panel/VBox/HBox/Prev" to="." method="_on_Prev_pressed"]
 [connection signal="pressed" from="Panel/VBox/HBox/Home" to="." method="_on_Home_pressed"]
 [connection signal="pressed" from="Panel/VBox/HBox/BGColor" to="." method="_on_BGColor_pressed"]
-[connection signal="pressed" from="Panel/VBox/HBox/Next" to="." method="_on_Prev_pressed"]
 [connection signal="pressed" from="Panel/VBox/HBox/Next" to="." method="_on_Next_pressed"]
+[connection signal="pressed" from="Panel/VBox/HBox/Next" to="." method="_on_Prev_pressed"]
 [connection signal="gui_input" from="Panel/VBox/TextureRect" to="." method="_on_TextureRect_gui_input"]
 [connection signal="color_changed" from="ColorPopup/ColorPicker" to="." method="_on_ColorPicker_color_changed"]

--- a/addons/gdcef/demos/HelloCEF/CEF.gd
+++ b/addons/gdcef/demos/HelloCEF/CEF.gd
@@ -70,17 +70,17 @@ func _on_TextureRect_gui_input(event):
 		$Panel/Label.set_text("Failed getting Godot node " + browser1)
 		return
 	if event is InputEventMouseButton:
-		if event.button_index == BUTTON_WHEEL_UP:
+		if event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			browser.on_mouse_wheel_vertical(2)
-		elif event.button_index == BUTTON_WHEEL_DOWN:
+		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
 			browser.on_mouse_wheel_vertical(-2)
-		elif event.button_index == BUTTON_LEFT:
+		elif event.button_index == MOUSE_BUTTON_LEFT:
 			mouse_pressed = event.pressed
 			if event.pressed == true:
 				browser.on_mouse_left_down()
 			else:
 				browser.on_mouse_left_up()
-		elif event.button_index == BUTTON_RIGHT:
+		elif event.button_index == MOUSE_BUTTON_RIGHT:
 			mouse_pressed = event.pressed
 			if event.pressed == true:
 				browser.on_mouse_right_down()
@@ -107,10 +107,7 @@ func _input(event):
 		$Panel/Label.set_text("Failed getting Godot node " + browser1)
 		return
 	if event is InputEventKey:
-		if event.unicode != 0:
-			browser.on_key_pressed(event.unicode, event.pressed, event.shift, event.alt, event.control)
-		else:
-			browser.on_key_pressed(event.scancode, event.pressed, event.shift, event.alt, event.control)
+		browser.on_key_pressed(event.unicode, event.pressed, event.shift, event.alt, event.control)
 
 	pass
 
@@ -145,7 +142,7 @@ func _ready():
 
 	var S = $Panel/TextureRect.get_size()
 	var browser = $CEF.create_browser("https://github.com/Lecrapouille/gdcef", browser1, S.x, S.y, {"javascript":true})
-	browser.connect("page_loaded", self, "_on_page_loaded")
+	browser.connect("page_loaded", _on_page_loaded)
 	$Panel/TextureRect.texture = browser.get_texture()
 
 # ==============================================================================

--- a/addons/gdcef/demos/HelloCEF/CEF.tscn
+++ b/addons/gdcef/demos/HelloCEF/CEF.tscn
@@ -1,77 +1,60 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource path="res://CEF.gd" type="Script" id=1]
-[ext_resource path="res://libs/gdcef.gdns" type="Script" id=2]
+[ext_resource type="Script" path="res://CEF.gd" id="1"]
 
 [node name="GUI" type="Control"]
-margin_right = 280.0
-margin_bottom = 180.0
+layout_mode = 3
+anchors_preset = 0
 mouse_filter = 1
-script = ExtResource( 1 )
+script = ExtResource("1")
 
-[node name="CEF" type="Node" parent="."]
-script = ExtResource( 2 )
+[node name="CEF" type="GDCef" parent="."]
 
 [node name="Panel" type="Panel" parent="."]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_right = 1280.0
+offset_bottom = 720.0
 
 [node name="TextureRect" type="TextureRect" parent="Panel"]
-anchor_top = 0.015
-anchor_bottom = 0.015
-margin_left = 5.0
-margin_top = 28.3
-margin_right = 273.0
-margin_bottom = 158.3
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 0
-expand = true
+expand_mode = 1
 
 [node name="Label" type="Label" parent="Panel"]
-margin_left = 4.0
-margin_top = 163.0
-margin_right = 81.0
-margin_bottom = 177.0
+layout_mode = 0
 mouse_filter = 0
 text = "Hello world!"
 
 [node name="Label2" type="Label" parent="Panel"]
-margin_left = 7.0
-margin_top = 7.0
-margin_right = 41.0
-margin_bottom = 21.0
+layout_mode = 0
 mouse_filter = 0
 text = "URL:"
 
 [node name="Home" type="Button" parent="Panel"]
-margin_left = 208.0
-margin_top = 3.0
-margin_right = 259.0
-margin_bottom = 25.0
+layout_mode = 0
 text = "Home"
 
 [node name="Prev" type="Button" parent="Panel"]
-margin_left = 186.0
-margin_top = 3.0
-margin_right = 206.0
-margin_bottom = 25.0
+layout_mode = 0
 text = "<"
 
 [node name="Next" type="Button" parent="Panel"]
-margin_left = 259.0
-margin_top = 3.0
-margin_right = 279.0
-margin_bottom = 25.0
+layout_mode = 0
 text = ">"
 
 [node name="TextEdit" type="LineEdit" parent="Panel"]
-margin_left = 43.0
-margin_top = 2.0
-margin_right = 185.0
-margin_bottom = 26.0
+layout_mode = 0
 
 [connection signal="gui_input" from="Panel/TextureRect" to="." method="_on_TextureRect_gui_input"]
 [connection signal="pressed" from="Panel/Home" to="." method="_on_Home_pressed"]
 [connection signal="pressed" from="Panel/Prev" to="." method="_on_Prev_pressed"]
-[connection signal="pressed" from="Panel/Next" to="." method="_on_Prev_pressed"]
 [connection signal="pressed" from="Panel/Next" to="." method="_on_Next_pressed"]
+[connection signal="pressed" from="Panel/Next" to="." method="_on_Prev_pressed"]
 [connection signal="text_changed" from="Panel/TextEdit" to="." method="_on_TextEdit_text_changed"]

--- a/addons/gdcef/demos/HelloCEF/Control.gd
+++ b/addons/gdcef/demos/HelloCEF/Control.gd
@@ -48,17 +48,17 @@ func _on_Texture1_gui_input(event):
 		$Panel/Label.set_text("Failed getting Godot node 'left'")
 		return
 	if event is InputEventMouseButton:
-		if event.button_index == BUTTON_WHEEL_UP:
+		if event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			browser.on_mouse_wheel_vertical(2)
-		elif event.button_index == BUTTON_WHEEL_DOWN:
+		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
 			browser.on_mouse_wheel_vertical(-2)
-		elif event.button_index == BUTTON_LEFT:
+		elif event.button_index == MOUSE_BUTTON_LEFT:
 			mouse_pressed = event.pressed
 			if event.pressed == true:
 				browser.on_mouse_left_down()
 			else:
 				browser.on_mouse_left_up()
-		elif event.button_index == BUTTON_RIGHT:
+		elif event.button_index == MOUSE_BUTTON_RIGHT:
 			mouse_pressed = event.pressed
 			if event.pressed == true:
 				browser.on_mouse_right_down()

--- a/addons/gdcef/demos/HelloCEF/Control.tscn
+++ b/addons/gdcef/demos/HelloCEF/Control.tscn
@@ -1,36 +1,23 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource path="res://Control.gd" type="Script" id=2]
-[ext_resource path="res://libs/gdcef.gdns" type="Script" id=3]
+[ext_resource type="Script" path="res://Control.gd" id="2"]
 
 [node name="Control" type="Control"]
-margin_left = -32.0
-margin_top = -35.0
-margin_right = 728.0
-margin_bottom = 536.0
-script = ExtResource( 2 )
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("2")
 
 [node name="Texture1" type="TextureRect" parent="."]
+layout_mode = 0
 anchor_right = 0.149
 anchor_bottom = 0.179
-margin_left = 34.0
-margin_top = 47.0
-margin_right = 143.76
-margin_bottom = 179.791
 
 [node name="Texture2" type="TextureRect" parent="."]
+layout_mode = 0
 anchor_right = 0.113
 anchor_bottom = 0.151
-margin_left = 322.0
-margin_top = 167.0
-margin_right = 377.12
-margin_bottom = 212.779
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="CEF" type="Node" parent="."]
-script = ExtResource( 3 )
+[node name="CEF" type="GDCef" parent="."]
 
 [node name="Timer" type="Timer" parent="."]
 wait_time = 6.0

--- a/addons/gdcef/gdcef/SConstruct
+++ b/addons/gdcef/gdcef/SConstruct
@@ -81,7 +81,7 @@ if platform == '':
 archi = env['arch']
 arch_ext = archi
 if archi == 'x86_64':
-    if platform != 'osx':
+    if platform != 'osx' and platform != 'windows':
         arch_ext = '64'
 
 # Check if Godot exists
@@ -132,7 +132,7 @@ elif platform == 'windows':
     # This makes sure to keep the session environment variables on windows,
     # that way you can run scons in a vs 2017 prompt and it will find all the required tools
     env.Append(ENV=os.environ)
-    env.Append(CPPDEFINES=['WIN32', '_WIN32', '_WINDOWS', '_CRT_SECURE_NO_WARNINGS'])
+    env.Append(CPPDEFINES=['WIN32', '_WIN32', '_WINDOWS', '_CRT_SECURE_NO_WARNINGS', 'TYPED_METHOD_BIND'])
     env.Append(CCFLAGS=['-W3', '-GR'])
     env.Append(CXXFLAGS='/std:c++17')
     if compile_mode == 'debug':
@@ -184,8 +184,7 @@ env.Append(CPPPATH=['.',
                     godot_api_path + '/include/gen'])
 
 # Godot library that is linked against our library
-#libgodot = 'libgodot-cpp.' + platform + '.' + compile_mode + '.' + arch_ext
-libgodot = libgodot = 'libgodot-cpp.' + platform + '.template_debug.x86_64.a'
+libgodot = 'libgodot-cpp.' + platform + '.template_' + compile_mode + '.' + arch_ext
 env.Append(LIBS=[libgodot], LIBPATH=[godot_api_path + '/bin'])
 
 # Pathes of CEF header files
@@ -213,7 +212,7 @@ env.Append(LIBS = [libcef, 'libcef_dll_wrapper'],
 env.Append(CPPPATH=['src/'])
 
 # Compile the library
-sources = ['src/helper_files.cpp', 'src/browser_io.cpp', 'src/gdcef.cpp', 'src/gdbrowser.cpp', 'src/gdextension.cpp']
+sources = ['src/helper_files.cpp', 'src/browser_io.cpp', 'src/gdcef.cpp', 'src/gdbrowser.cpp', 'src/register_types.cpp']
 # sources = Glob('src/*.cpp')
 # sources = ['src/helper_files.cpp', 'src/browser_io.cpp', 'src/gdcef.cpp', 'src/gdbrowser.cpp', 'src/gdnative.cpp']
 library = env.SharedLibrary(target=target_path + '/' + target_library, source=sources)

--- a/addons/gdcef/gdcef/src/gdcef.cpp
+++ b/addons/gdcef/gdcef/src/gdcef.cpp
@@ -92,7 +92,6 @@ void GDCef::_bind_methods()
     std::cout << "[GDCEF][GDCef::_register_methods]" << std::endl;
 
     ClassDB::bind_method(D_METHOD("initialize"), &GDCef::initialize);
-    ClassDB::bind_method(D_METHOD("_process"), &GDCef::_process);
     ClassDB::bind_method(D_METHOD("get_full_version"), &GDCef::version);
     ClassDB::bind_method(D_METHOD("get_version_part"), &GDCef::versionPart);
     ClassDB::bind_method(D_METHOD("create_browser"), &GDCef::createBrowser);
@@ -205,7 +204,7 @@ godot::String GDCef::getError()
 }
 
 //------------------------------------------------------------------------------
-void GDCef::_process(float /*delta*/)
+void GDCef::_process(double /*delta*/)
 {
     if (m_impl != nullptr)
     {
@@ -445,7 +444,6 @@ GDBrowserView* GDCef::createBrowser(godot::String const url, godot::String const
 {
     GDCEF_DEBUG_VAL("name: " << name.utf8().get_data() <<
                     ", url: " << url.utf8().get_data());
-
     if (m_impl == nullptr)
     {
         GDCEF_ERROR("CEF was not initialized");
@@ -453,12 +451,7 @@ GDBrowserView* GDCef::createBrowser(godot::String const url, godot::String const
     }
 
     // Godot node creation (note Godot cannot pass arguments to _new())
-    GDBrowserView* browser = new GDBrowserView();//::_new();
-    if (browser == nullptr)
-    {
-        GDCEF_ERROR("new BrowserView() failed");
-        return nullptr;
-    }
+    GDBrowserView* browser = memnew(GDBrowserView);
 
     // Complete BrowserView constructor (complete _new())
     CefBrowserSettings settings;

--- a/addons/gdcef/gdcef/src/gdcef.hpp
+++ b/addons/gdcef/gdcef/src/gdcef.hpp
@@ -130,7 +130,7 @@ public: // Godot interfaces.
     //! \brief Process automatically called by Godot engine. Call the CEF pomp
     //! loop message.
     // -------------------------------------------------------------------------
-    void _process(float delta);
+    void _process(double delta) override;
 
 protected:
 

--- a/addons/gdcef/gdcef/src/gdextension.hpp
+++ b/addons/gdcef/gdcef/src/gdextension.hpp
@@ -1,7 +1,0 @@
-#ifndef GDEXAMPLE_REGISTER_TYPES_H
-#define GDEXAMPLE_REGISTER_TYPES_H
-
-void initialize_gdcef_module();
-void uninitialize_gdcef_module();
-
-#endif // GDEXAMPLE_REGISTER_TYPES_H

--- a/addons/gdcef/gdcef/src/helper_log.hpp
+++ b/addons/gdcef/gdcef/src/helper_log.hpp
@@ -47,7 +47,6 @@
 #define BROWSER_ERROR(x)                                                   \
   m_error << "[GDCEF][BrowserView::" << __func__ << "][" << m_id << "] "   \
           << x << std::endl;                                               \
-  /*godot::Godot::print(m_error.str().c_str()); */                             \
   std::cerr << m_error.str()
 
 #endif // STIGMEE_GDCEF_HELPER_LOG_HPP

--- a/addons/gdcef/gdcef/src/register_types.cpp
+++ b/addons/gdcef/gdcef/src/register_types.cpp
@@ -23,12 +23,12 @@
 // SOFTWARE.
 //*****************************************************************************
 
-#include "gdextension.hpp"
+#include "register_types.h"
+
 #include "gdcef.hpp"
 #include "gdbrowser.hpp"
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
-#include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/godot.hpp>
 
 using namespace godot;
@@ -51,11 +51,8 @@ void uninitialize_gdcef_module(ModuleInitializationLevel p_level)
 extern "C" {
 
     // Initialization.
-    GDExtensionBool GDE_EXPORT example_library_init(const GDExtensionInterface *p_interface,
-                                                    const GDExtensionClassLibraryPtr p_library,
-                                                    GDExtensionInitialization *r_initialization)
-    {
-        godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+    GDExtensionBool GDE_EXPORT gdcef_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+        godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
         init_obj.register_initializer(initialize_gdcef_module);
         init_obj.register_terminator(uninitialize_gdcef_module);

--- a/addons/gdcef/gdcef/src/register_types.h
+++ b/addons/gdcef/gdcef/src/register_types.h
@@ -1,0 +1,11 @@
+#ifndef GDCEF_REGISTER_TYPES_H
+#define GDCEF_REGISTER_TYPES_H
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void initialize_gdcef_module(ModuleInitializationLevel p_level);
+void uninitialize_gdcef_module(ModuleInitializationLevel p_level);
+
+#endif // GDCEF_REGISTER_TYPES_H

--- a/addons/gdcef/subprocess/SConstruct
+++ b/addons/gdcef/subprocess/SConstruct
@@ -80,7 +80,7 @@ if platform == '':
 archi = env['arch']
 arch_ext = archi
 if archi == 'x86_64':
-    if platform != 'osx':
+    if platform != 'osx' and platform != 'windows':
         arch_ext = '64'
 
 # Check if Godot exists
@@ -181,8 +181,7 @@ env.Append(CPPPATH=['.',
                     godot_api_path + '/include/gen'])
 
 # Godot library that is linked against our library
-#libgodot = 'libgodot-cpp.' + platform + '.' + compile_mode + '.' + arch_ext
-libgodot = 'libgodot-cpp.' + platform + '.template_debug.x86_64.a'
+libgodot = 'libgodot-cpp.' + platform + '.template_' + compile_mode + '.' + arch_ext
 env.Append(LIBS=[libgodot], LIBPATH=[godot_api_path + '/bin'])
 
 # Pathes of CEF header files


### PR DESCRIPTION
This isn't really a full port and I can't dedicate the time to make everything neat, so submitting it as a draft. Feel free to use as a base or build upon this. 

The basics of the 2D demo are working in Godot 4.2 (via gdextension below, did not test gdnative). I was able to view the GitHub page, interact with it, and watched YouTube with both Video and Audio. The 3D demo was left untouched for now and I've only tested on Windows.

**Changes**
- Update `GODOT_VERSION` to `4.2`
- `GODOT_CPP_TARGET` must now be either `template_release` or `template_debug`
- Removed `GODOT_EXECUTABLE` and generation of `extension_api.json` to use the one shipped in the godot-cpp repository instead
- Disabled the cef patches on Windows because they seemed to cause linking issues and it seems to work without now?
- Added `"use_static_cpp=no"` to godot-cpp build to fix dynamic vs static linking issues
- Updated 2D demo to be able to run successfully (however, I did not update or test any of the advanced features like the color picker)
- Updated the HelloCEF demo to be able to run successfully (however, the GUI seems to have gotten mangled a bit and I did not update or test anything in relation to that)
- Disabled `arch_ext = '64'` override on Windows as well since Windows builds now end in `x86_64` - maybe this applies to linux too? not sure
- Added `'TYPED_METHOD_BIND'` to defines to fix compile errors on Windows when returning `GDBrowserView*` in the bound `createBrowser` method
- Renamed `gdextension.cpp` to `register_types.cpp` to match the example on Godot docs and maybe fix a weird conflict error I ran into (but not sure if that did anything to help or it was something else)
- Added missing signal registration (taken from [eProgD's fork](https://github.com/eProgD/gdcef/commit/8228a0f8b28176b718e201d2a92a396a0e2aa9ea) 🙏)
- Fixed and re-enabled `onPaint` (with color correction taken from [eProgD's fork](https://github.com/eProgD/gdcef/commit/8228a0f8b28176b718e201d2a92a396a0e2aa9ea) 🙏)
- Instantiate `GDBrowserView` using `memnew` as otherwise the engine would consider it just an empty node
- Updated `_process` to now take a `double` for `delta` and remove it from `bind_methods` since it's an existing engine method
- Updated gdextension entrypoint to signature used in Godot 4.2

The barebones `gdcef.gdextension` I used for testing (obviously not using correct targets) is below. I also had to update the cef artifacts path to use that same bin folder but did not change this in the build script since it seemed more involved.

```ini
[configuration]
entry_symbol = "gdcef_library_init"
compatibility_minimum = 4.2

[libraries]
linux.x86_64.debug = "bin/libgdcef.so"
linux.x86_64.release = "bin/libgdcef.so"
linux.x86_32.debug = "bin/libgdcef.so"
linux.x86_32.release = "bin/libgdcef.so"

windows.x86_64.debug = "bin/libgdcef.dll"
windows.x86_64.release = "bin/libgdcef.dll"
windows.x86_32.debug = "bin/libgdcef.dll"
windows.x86_32.release = "bin/libgdcef.dll"

macos.debug = "bin/Frameworks/Chromium\ Embedded\ Framework.framework/Libraries/libgdcef.dylib"
macos.release = "bin/Frameworks/Chromium\ Embedded\ Framework.framework/Libraries/libgdcef.dylib"
```

#30 