### PR TITLE
Update installation.md

### DIFF
--- a/addons/gdcef/doc/installation.md
+++ b/addons/gdcef/doc/installation.md
@@ -19,6 +19,7 @@ This document supposes you want to compile gdCEF module for Godot 4.2+ for Linux
 Install the following tools: `scons, g++, ninja, cmake, git, python3` (version 3.21.0 or higher). We are using C++20, but we are not using fancy C++ features - we just need this version for using `std::filesystem`. We are also using OpenMP by default to parallelize some CPU tasks. It is by default enabled for Linux and Windows. For MacOS, you need to install [openmp](https://www.youtube.com/playlist?list=PLLX-Q6B8xqZ8n8bwjGdzBJ25X2utwnoEG).You can disable it in the `build.py` script.
 
 - For Linux, depending on your distribution you can use `sudo apt-get install`.
+- For Linux, you may need to install `libx11-dev` (`libX11-devel` for Redhat based systems) for the compilation of the Chromium Embedded Framework
 - For macOS X you can install [homebrew](https://brew.sh/).
 - For Windows users you will have to install:
 -


### PR DESCRIPTION
Build.py fails under fedora 43 at the moment at "[INFO] Compiling Chromium Embedded Framework in Release mode" This error is fixed by installing the x11devel package.  It's possible that some distros that still use x11 don't need the additional package. Added a line indicating this in the build instructions.