### PR TITLE
do not use `WARN_PRINT` for debug info

### DIFF
--- a/gdcef/browser/src/gdbrowser.cpp
+++ b/gdcef/browser/src/gdbrowser.cpp
@@ -223,7 +223,7 @@ GdBrowserView::Impl::~Impl()
 // methods of this class to Godot.
 void GdBrowserView::_bind_methods()
 {
-    WARN_PRINT("[gdCEF][GdBrowserView::_bind_methods]");
+    GDCEF_DEBUG("[gdCEF][GdBrowserView::_bind_methods]");
 
     using namespace godot;
 

--- a/gdcef/browser/src/helper_log.hpp
+++ b/gdcef/browser/src/helper_log.hpp
@@ -28,6 +28,7 @@
 
 // Godot 4
 #include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/core/print_string.hpp>
 #include <godot_cpp/variant/string.hpp>
 
 #include <sstream>
@@ -47,7 +48,7 @@
     {                                                     \
         std::stringstream ss;                             \
         ss << "[gdCEF][gdCEF::" << __func__ << "] " << x; \
-        WARN_PRINT(godot::String(ss.str().c_str()));      \
+        godot::print_verbose(godot::String(ss.str().c_str()));      \
     }
 
 #define GDCEF_ERROR(x)                                    \
@@ -70,7 +71,7 @@
         godot::String name = get_name();                                \
         ss << "[gdCEF][GdBrowserView::" << __func__ << "][id: " << m_id \
            << ", name: " << name.utf8().get_data() << "] " << txt;      \
-        WARN_PRINT(godot::String(ss.str().c_str()));                    \
+        godot::print_verbose(godot::String(ss.str().c_str()));                    \
     }
 
 #define BROWSER_ERROR(txt)                                              \


### PR DESCRIPTION
Use `godot::print_verbose` (instead of for `WARN_PRINT`) debug info printing.