### PR TITLE
Fix compiler check failing when the current directory is not in PATH

### DIFF
--- a/build.py
+++ b/build.py
@@ -699,7 +699,7 @@ def check_compiler():
             fatal("MS C++ compiler is not working. "
                   "Please install Visual Studio (https://visualstudio.microsoft.com) "
                   "and open an x64 Native Tools Command Prompt for VS 2022 with Administrator privileges.")
-        if os.system(binfile) != 0:
+        if os.system(os.path.join(".", binfile)) != 0:
             os.remove(cppfile)
             fatal("MS C++ compiler failed to build a test program. "
                   "Please install Visual Studio (https://visualstudio.microsoft.com) "


### PR DESCRIPTION
Fixes #99

## Symptom

On some Windows setups, `build.py` aborts with:

```
[FATAL] MS C++ compiler failed to build a test program. Please install Visual Studio ...
```

…even though MSVC is correctly installed and the test program **did** compile (both `cl.exe` invocation and `win.exe` creation succeed — the log right above the fatal shows the successful compile/link).

## Cause

`check_compiler()` runs the freshly built test binary with `os.system(binfile)` — i.e. the bare name `win.exe`. That relies on `cmd` resolving the name from the current directory, which fails on machines where the working directory is not part of the executable search path (the `NoDefaultCurrentDirectoryInExePath` environment setting, and shells spawned from PowerShell-based environments behave this way). The command fails with *"'win.exe' is not recognized as an internal or external command"* and the check misreports a broken compiler.

## Fix

Run the binary with an explicit path: `os.system(os.path.join(".", binfile))` → `.\win.exe`. One line; behavior unchanged on setups where the bare name already worked.

Hit this while building the multi-touch branch on a stock VS 2022 Community install; with this fix the same environment builds to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
